### PR TITLE
make readme.md example compile

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ This is a **nightly** crate. You _must_ include the following line in your code 
 
 ```rust
 #![feature(unboxed_closures, fn_traits)]
-use overloadable::overload;
+use overloadable::overloadable;
 
 overloadable! {
     pub func as
@@ -32,9 +32,9 @@ overloadable! {
     }
 }
 
-fn foo {
+fn foo() {
     assert_eq!(func(2, 3), 6);
     assert_eq!(func(&32), 32.0);
-    assert_eq!(func(&[1, 2, 3, 4] as &[usize]), &0);
+    assert_eq!(func(&[1, 2, 3, 4][..]), &0);
 }
 ```


### PR DESCRIPTION
read about your crate on [this week in rust](https://this-week-in-rust.org/blog/2019/07/16/this-week-in-rust-295/#crate-of-the-week) and thought to try it out. i found two locations where my rustc (1.36.0-nightly a19cf18c7) wouldn't compile the example from readme.md, so here are the changes i needed.

i tried to get something to work using the [doc-comment](https://docs.rs/doc-comment/0.3.1/doc_comment/) crate to check the readme examples with cargo test as well, but didn't get it to actually run the readme test (it says `0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out` here), my changes are in the [use-doc-comment branch](https://github.com/dario23/overloadable/tree/use-doc-comment) of my fork if you want to take a look :-)